### PR TITLE
Add `version-file` input

### DIFF
--- a/.github/actions/go-aio/action.yaml
+++ b/.github/actions/go-aio/action.yaml
@@ -17,7 +17,7 @@ inputs:
   version-file:
     description: "Go version file (go.mod)"
     required: false
-    default: ""
+    default: "go.mod"
 
 runs:
   using: "composite"

--- a/.github/actions/go-aio/action.yaml
+++ b/.github/actions/go-aio/action.yaml
@@ -12,8 +12,12 @@ inputs:
     default: ""
   version:
     description: "Go version"
-    required: true
+    required: false
     default: "1.18"
+  version-file:
+    description: "Go version file (go.mod)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -21,6 +25,7 @@ runs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.version }}
+        go-version-file: ${{ inputs.version-file }}
         architecture: x64
         cache: true
     - run: git config --global url.https://${{ inputs.user }}:${{ inputs.pat }}@github.com/.insteadOf https://github.com/

--- a/.github/actions/go-aio/action.yaml
+++ b/.github/actions/go-aio/action.yaml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.version }}
         go-version-file: ${{ inputs.version-file }}


### PR DESCRIPTION
This PR adds an input argument to set `action/setup-go@v3`'s `go-version-file` parameter. Using this argument we just point to the `go.mod` file and there's no need to update the version manually in the workflow arguments.