### PR TITLE
Remove default value for `version` input

### DIFF
--- a/.github/actions/go-aio/action.yaml
+++ b/.github/actions/go-aio/action.yaml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "Go version"
     required: false
-    default: "1.18"
+    default: ""
   version-file:
     description: "Go version file (go.mod)"
     required: false


### PR DESCRIPTION
The `version` input should have an empty default value, otherwise it'll always override the `version-file` value. 