### PR TITLE
Add security scan action

### DIFF
--- a/.github/actions/go-aio/action.yaml
+++ b/.github/actions/go-aio/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: "Go version file (go.mod)"
     required: false
     default: "go.mod"
+  vendor:
+    description: "Vendor Go dependencies"
+    required: false
+    default: true
 
 runs:
   using: "composite"
@@ -30,5 +34,6 @@ runs:
         cache: true
     - run: git config --global url.https://${{ inputs.user }}:${{ inputs.pat }}@github.com/.insteadOf https://github.com/
       shell: bash
-    - run: go mod vendor
+    - if: ${{ inputs.vendor == 'true' }}
+      run: go mod vendor
       shell: bash

--- a/.github/actions/security-scan/README.md
+++ b/.github/actions/security-scan/README.md
@@ -1,0 +1,2 @@
+# security-scan
+An action to run Go's vulnerability scanner on a repo as well as Trivy's repo scanner.

--- a/.github/actions/security-scan/action.yaml
+++ b/.github/actions/security-scan/action.yaml
@@ -1,0 +1,21 @@
+name: Security Scan
+description: "Run Go vulernability scan and Trivy repo scan"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Go Vulnerability Check
+      id: govulncheck
+      uses: golang/govulncheck-action@v1
+    - name: Run Trivy vulnerability scanner in repo mode
+      uses: aquasecurity/trivy-action@0.23.0
+      with:
+        scan-type: 'fs'
+        ignore-unfixed: true
+        format: 'table' 
+        severity: 'CRITICAL'
+        exit-code: '1'


### PR DESCRIPTION
# Description

This PR adds a composite action to run Go's vulnerability scanner on a repo as well as Trivy's repo scanner.

It also modifies the go-aio action to introduce a new input `vendor` optionally choose whether dependencies are vendored.

I've tested this action here https://github.com/kian99/livepatch-server/actions/runs/9804948865/job/27073673793