### PR TITLE
Revert uploading 

### DIFF
--- a/.github/actions/security-scan/action.yaml
+++ b/.github/actions/security-scan/action.yaml
@@ -1,6 +1,6 @@
 name: Security Scan
 description: |
-  Run Go vulernability scan and Trivy repo scan
+  Run Go vulernability scan and Trivy (CRITICAL and HIGH) repo scan for 
 
   This is designed to be run in CI and provides exit codes when vulnerabilities
   are found. 

--- a/.github/actions/security-scan/action.yaml
+++ b/.github/actions/security-scan/action.yaml
@@ -1,5 +1,9 @@
 name: Security Scan
-description: "Run Go vulernability scan and Trivy repo scan"
+description: |
+  Run Go vulernability scan and Trivy repo scan
+
+  This is designed to be run in CI and provides exit codes when vulnerabilities
+  are found. 
 
 runs:
   using: "composite"

--- a/.github/actions/security-scan/action.yaml
+++ b/.github/actions/security-scan/action.yaml
@@ -2,8 +2,8 @@ name: Security Scan
 description: |
   Run Go vulernability scan and Trivy (CRITICAL and HIGH) repo scan for 
 
-  This is designed to be run in CI and provides exit codes when vulnerabilities
-  are found. 
+  This is designed to be run in CI on pull requests and/or pushes and provides exit codes 
+  when vulnerabilities are found. 
 
 runs:
   using: "composite"


### PR DESCRIPTION
This composite action will be used only for CI scanning now, because it allows exit codes and format "table" for viewable vulns.