### PR TITLE
No longer checkout and specify go.mod for install from govuln

### DIFF
--- a/.github/actions/security-scan-upload/action.yaml
+++ b/.github/actions/security-scan-upload/action.yaml
@@ -35,11 +35,6 @@ runs:
           echo "  upload-sarif-artifact: ${{ inputs.upload-sarif-artifact }}"
           exit 1
         fi
-
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
     
     #########
     # Trivy #
@@ -75,6 +70,8 @@ runs:
       with:
         output-format: 'sarif'
         output-file: 'govuln-results.sarif'
+        go-version-file: go.mod
+        repo-checkout: false
 
     - name: Upload govuln scan results as artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Govuln installs go. We now remove duplicate installs and specify the action not to checkout, so we can checkout manually beforehand for specific branches. I think this will work? But have no way to test unless we merge this and I try it in my fork.