### PR TITLE
add suffix

### DIFF
--- a/.github/actions/security-scan-upload/action.yaml
+++ b/.github/actions/security-scan-upload/action.yaml
@@ -59,7 +59,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ inputs.upload-sarif-artifact == 'true' }}
       with:
-        name: 'trivy-security-scan-results-${{ inputs.result-suffix }}'
+        name: trivy-security-scan-results${{ inputs.result-suffix != '' && format('-{0}', inputs.result-suffix) || '' }}
         path: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
@@ -84,7 +84,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ inputs.upload-sarif-artifact == 'true' }}
       with:
-        name: 'govuln-security-scan-results-${{ inputs.result-suffix }}'
+        name: govuln-security-scan-results${{ inputs.result-suffix != '' && format('-{0}', inputs.result-suffix) || '' }}
         path: 'govuln-results.sarif'
 
     - name: Upload govuln scan results to GitHub Security tab

--- a/.github/actions/security-scan-upload/action.yaml
+++ b/.github/actions/security-scan-upload/action.yaml
@@ -21,6 +21,13 @@ inputs:
     description: 'Upload the SARIF outputs via actions/upload-artifact'
     required: false
     default: 'true'
+  result-suffix:
+    description: |
+      A suffix for the resulting upload-artifact.
+      For example, v3-branch would result in:
+        trivy-security-scan-results-v3-branch
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -52,7 +59,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ inputs.upload-sarif-artifact == 'true' }}
       with:
-        name: 'trivy-security-scan-results'
+        name: 'trivy-security-scan-results-${{ inputs.result-suffix }}'
         path: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
@@ -77,7 +84,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ inputs.upload-sarif-artifact == 'true' }}
       with:
-        name: 'govuln-security-scan-results'
+        name: 'govuln-security-scan-results-${{ inputs.result-suffix }}'
         path: 'govuln-results.sarif'
 
     - name: Upload govuln scan results to GitHub Security tab


### PR DESCRIPTION
Upload artifact v4 does not allow the same-name artifact to be uploaded again in a single workflow run. This allows us to put a suffix on the end of the resulting artifact name, i.e., v3, develop, master, so forth. I named it more generically incase others use this and don't want to put branch names a hash for example.