### PR TITLE
use unique name for container scan results

### DIFF
--- a/.github/actions/security-scan-upload/action.yaml
+++ b/.github/actions/security-scan-upload/action.yaml
@@ -87,7 +87,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ inputs.upload-sarif-artifact == 'true' && inputs.container-name != '' }}
       with:
-        name: trivy-security-scan-results${{ inputs.result-suffix != '' && format('-{0}', inputs.result-suffix) || '' }}
+        name: container-scan-results-${{ inputs.container-name }}${{ inputs.result-suffix != '' && format('-{0}', inputs.result-suffix) || '' }}
         path: 'container-trivy-results.sarif'
 
     - name: Upload container Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Use a unique name when uploading the sarif file for container scans.
Without unique names there are errors in a workflow run due to duplicate artefact names as seen below.
https://github.com/canonical/jimm/actions/runs/13280073848/job/37076511859
`Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`