### PR TITLE
Update container scan result name

### DIFF
--- a/.github/actions/security-scan-upload/action.yaml
+++ b/.github/actions/security-scan-upload/action.yaml
@@ -87,7 +87,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ inputs.upload-sarif-artifact == 'true' && inputs.container-name != '' }}
       with:
-        name: container-scan-results-${{ inputs.container-name }}${{ inputs.result-suffix != '' && format('-{0}', inputs.result-suffix) || '' }}
+        name: container-scan-results${{ inputs.result-suffix != '' && format('-{0}', inputs.result-suffix) || '' }}
         path: 'container-trivy-results.sarif'
 
     - name: Upload container Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Update the container scan artefact name to avoid conflicts with Github's naming scheme, the error encountered is below:

>The artifact name is not valid: container-scan-results-ghcr.io/canonical/jimm:latest. Contains the following character:  Colon :
>         
>Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, >Carriage return \r, Line feed \n, Backslash \, Forward slash /
>          
>These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file >system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on >different file systems.
